### PR TITLE
ページの描画位置が共有されているバグの修正

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -20,6 +20,13 @@ Vue.use(Router)
 export default new Router({
   mode: 'history',
   base: process.env.BASE_URL,
+  scrollBehavior (to, from, savedPosition) {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve({ x: 0, y: 0 })
+      }, 250)
+    })
+  },
   routes: [
     {
       path: '/',


### PR DESCRIPTION
Close #104
うまく説明できないんですけど、https://booq-dev.tokyotech.org/about を下までスクロールした後にRegister Itemをクリックすると一番下までスクロールされた状態でページ遷移してしまうバグを解消しました

これは何をしているかというと、ページ遷移が行われるたびに位置をリセットする処理を入れています
参考: https://router.vuejs.org/ja/guide/advanced/scroll-behavior.html