### PR TITLE
returnの型の成型とクエリの改善

### DIFF
--- a/model/items.go
+++ b/model/items.go
@@ -21,7 +21,7 @@ type Item struct {
 
 type Owner struct {
 	gorm.Model
-	UserId     uint `gorm:"type:int;not null" json:"owner_id"`
+	UserID     uint `gorm:"type:int;not null" json:"owner_id"`
 	User       User `json:"owner"`
 	Rentalable bool `gorm:"type:bool;not null" json:"rentalable"`
 	Count      int  `gorm:"type:int;default:1" json:"count"`
@@ -108,9 +108,9 @@ func CreateItem(item Item) (Item, error) {
 func RegisterOwner(owner Owner, item Item) (Item, error) {
 	var existed bool
 	db.Preload("Owners").Find(&item)
-	owner.User, _ = GetUserByID(int(owner.UserId))
+	owner.User, _ = GetUserByID(int(owner.UserID))
 	for _, nowOwner := range item.Owners {
-		if nowOwner.UserId != owner.UserId {
+		if nowOwner.UserID != owner.UserID {
 			continue
 		}
 		if owner.Rentalable == nowOwner.Rentalable {

--- a/model/items_test.go
+++ b/model/items_test.go
@@ -12,6 +12,7 @@ func TestItemTableName(t *testing.T) {
 }
 
 func TestCreateItem(t *testing.T) {
+
 	t.Parallel()
 
 	t.Run("failures", func(t *testing.T) {
@@ -43,30 +44,34 @@ func TestCreateItem(t *testing.T) {
 }
 
 func TestRegisterOwner(t *testing.T) {
+
 	user, _ := CreateUser(User{Name: "testRegisterOwnerUser"})
 	var owner Owner
-	owner.OwnerID = user.ID
+	owner.UserId = user.ID
 	owner.Rentalable = true
 	owner.Count = 1
 	item, _ := CreateItem(Item{Name: "testRegisterOwnerItem"})
 	item2, err := RegisterOwner(owner, item)
+
 	t.Run("make success", func(t *testing.T) {
-		t.Parallel()
+
 		assert := assert.New(t)
 
-		assert.Equal(user.ID, item2.Owners[0].OwnerID)
+		assert.Equal(user.ID, item2.Owners[0].UserId)
+		assert.Equal(user.Name, item2.Owners[0].User.Name)
 		assert.NoError(err)
 		assert.NotEmpty(item2)
 	})
 
 	t.Run("add success", func(t *testing.T) {
-		t.Parallel()
+
 		assert := assert.New(t)
 
 		owner.Count = 5
 		item, err := RegisterOwner(owner, item)
 
 		assert.Equal(6, item.Owners[0].Count)
+		assert.Equal(item.Owners[0].User.Name, user.Name)
 
 		assert.NoError(err)
 		assert.NotEmpty(item)
@@ -74,26 +79,30 @@ func TestRegisterOwner(t *testing.T) {
 }
 
 func TestGetItems(t *testing.T) {
+
 	user, _ := CreateUser(User{Name: "testAllItemUser"})
 	var owner Owner
-	owner.OwnerID = user.ID
+	owner.UserId = user.ID
 	owner.Rentalable = true
 	owner.Count = 1
 	item, _ := CreateItem(Item{Name: "testAllItemItem"})
 	_, _ = RegisterOwner(owner, item)
+
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
 		items, err := GetItems()
+		assert.NoError(err)
+
 		for _, value := range items {
 			if value.Name == "testAllItemItem" {
-				assert.Equal(user.ID, value.Owners[0].OwnerID)
+				assert.Equal(user.ID, value.Owners[0].UserId)
+				assert.Equal(user.Name, value.Owners[0].User.Name)
 				break
 			}
 			continue
 		}
-		assert.NoError(err)
 		assert.NotEmpty(items)
 	})
 }
@@ -103,20 +112,19 @@ func TestGetItemByID(t *testing.T) {
 	ownerUser, _ := CreateUser(User{Name: "testGetItemByIDOwner"})
 	rentalUser, _ := CreateUser(User{Name: "testGetItemByIDUser"})
 	owner := Owner{
-		OwnerID:    ownerUser.ID,
+		UserId:     ownerUser.ID,
 		Rentalable: true,
 		Count:      1,
 	}
 
 	t.Run("success", func(t *testing.T) {
 
-		t.Parallel()
 		assert := assert.New(t)
 		item, err := CreateItem(Item{Name: "testGetItemItem"})
 		assert.NoError(err)
 		_, err = RegisterOwner(owner, item)
 		assert.NoError(err)
-		_, err = CreateLog(Log{ItemID: item.ID, OwnerID: owner.OwnerID, UserID: rentalUser.ID, Type: 0, Count: 1})
+		_, err = CreateLog(Log{ItemID: item.ID, OwnerId: owner.UserId, UserId: rentalUser.ID, Type: 0, Count: 1})
 		assert.NoError(err)
 
 		gotItem, err := GetItemByID(item.ID)
@@ -124,8 +132,44 @@ func TestGetItemByID(t *testing.T) {
 		assert.NoError(err)
 		assert.NotEmpty(gotItem)
 		assert.Equal(gotItem.Name, "testGetItemItem")
-		assert.Equal(gotItem.Owners[0].OwnerID, ownerUser.ID)
-		assert.Equal(gotItem.Logs[0].OwnerID, ownerUser.ID)
+		assert.Equal(gotItem.Owners[0].UserId, ownerUser.ID)
+		assert.Equal(gotItem.Owners[0].User.Name, ownerUser.Name)
+		assert.Equal(gotItem.Logs[0].OwnerId, ownerUser.ID)
+		assert.Equal(gotItem.Logs[0].Owner.Name, ownerUser.Name)
+		assert.Equal(gotItem.Logs[0].Count, 1)
+		assert.Equal(gotItem.Logs[0].ItemID, item.ID)
+	})
+}
+
+func TestGetItemByName(t *testing.T) {
+
+	ownerUser, _ := CreateUser(User{Name: "testGetItemByNameOwner"})
+	rentalUser, _ := CreateUser(User{Name: "testGetItemByNameUser"})
+	owner := Owner{
+		UserId:     ownerUser.ID,
+		Rentalable: true,
+		Count:      1,
+	}
+
+	t.Run("success", func(t *testing.T) {
+
+		assert := assert.New(t)
+
+		item, err := CreateItem(Item{Name: "testGetItemByNameItem"})
+		assert.NoError(err)
+		_, err = RegisterOwner(owner, item)
+		assert.NoError(err)
+		_, err = CreateLog(Log{ItemID: item.ID, OwnerId: owner.UserId, UserId: rentalUser.ID, Type: 0, Count: 1})
+		assert.NoError(err)
+		gotItem, err := GetItemByName(item.Name)
+
+		assert.NoError(err)
+		assert.NotEmpty(gotItem)
+		assert.Equal(gotItem.Name, "testGetItemByNameItem")
+		assert.Equal(gotItem.Owners[0].UserId, ownerUser.ID)
+		assert.Equal(gotItem.Owners[0].User.Name, ownerUser.Name)
+		assert.Equal(gotItem.Logs[0].OwnerId, ownerUser.ID)
+		assert.Equal(gotItem.Logs[0].Owner.Name, ownerUser.Name)
 		assert.Equal(gotItem.Logs[0].Count, 1)
 		assert.Equal(gotItem.Logs[0].ItemID, item.ID)
 	})

--- a/model/items_test.go
+++ b/model/items_test.go
@@ -12,7 +12,6 @@ func TestItemTableName(t *testing.T) {
 }
 
 func TestCreateItem(t *testing.T) {
-
 	t.Parallel()
 
 	t.Run("failures", func(t *testing.T) {
@@ -44,7 +43,6 @@ func TestCreateItem(t *testing.T) {
 }
 
 func TestRegisterOwner(t *testing.T) {
-
 	user, _ := CreateUser(User{Name: "testRegisterOwnerUser"})
 	var owner Owner
 	owner.UserId = user.ID
@@ -79,7 +77,6 @@ func TestRegisterOwner(t *testing.T) {
 }
 
 func TestGetItems(t *testing.T) {
-
 	user, _ := CreateUser(User{Name: "testAllItemUser"})
 	var owner Owner
 	owner.UserId = user.ID
@@ -108,7 +105,6 @@ func TestGetItems(t *testing.T) {
 }
 
 func TestGetItemByID(t *testing.T) {
-
 	ownerUser, _ := CreateUser(User{Name: "testGetItemByIDOwner"})
 	rentalUser, _ := CreateUser(User{Name: "testGetItemByIDUser"})
 	owner := Owner{
@@ -142,7 +138,6 @@ func TestGetItemByID(t *testing.T) {
 }
 
 func TestGetItemByName(t *testing.T) {
-
 	ownerUser, _ := CreateUser(User{Name: "testGetItemByNameOwner"})
 	rentalUser, _ := CreateUser(User{Name: "testGetItemByNameUser"})
 	owner := Owner{

--- a/model/items_test.go
+++ b/model/items_test.go
@@ -52,7 +52,6 @@ func TestRegisterOwner(t *testing.T) {
 	item2, err := RegisterOwner(owner, item)
 
 	t.Run("make success", func(t *testing.T) {
-
 		assert := assert.New(t)
 
 		assert.Equal(user.ID, item2.Owners[0].UserId)
@@ -62,7 +61,6 @@ func TestRegisterOwner(t *testing.T) {
 	})
 
 	t.Run("add success", func(t *testing.T) {
-
 		assert := assert.New(t)
 
 		owner.Count = 5
@@ -114,7 +112,6 @@ func TestGetItemByID(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
-
 		assert := assert.New(t)
 		item, err := CreateItem(Item{Name: "testGetItemItem"})
 		assert.NoError(err)
@@ -147,7 +144,6 @@ func TestGetItemByName(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
-
 		assert := assert.New(t)
 
 		item, err := CreateItem(Item{Name: "testGetItemByNameItem"})

--- a/model/items_test.go
+++ b/model/items_test.go
@@ -45,7 +45,7 @@ func TestCreateItem(t *testing.T) {
 func TestRegisterOwner(t *testing.T) {
 	user, _ := CreateUser(User{Name: "testRegisterOwnerUser"})
 	var owner Owner
-	owner.UserId = user.ID
+	owner.UserID = user.ID
 	owner.Rentalable = true
 	owner.Count = 1
 	item, _ := CreateItem(Item{Name: "testRegisterOwnerItem"})
@@ -54,7 +54,7 @@ func TestRegisterOwner(t *testing.T) {
 	t.Run("make success", func(t *testing.T) {
 		assert := assert.New(t)
 
-		assert.Equal(user.ID, item2.Owners[0].UserId)
+		assert.Equal(user.ID, item2.Owners[0].UserID)
 		assert.Equal(user.Name, item2.Owners[0].User.Name)
 		assert.NoError(err)
 		assert.NotEmpty(item2)
@@ -77,7 +77,7 @@ func TestRegisterOwner(t *testing.T) {
 func TestGetItems(t *testing.T) {
 	user, _ := CreateUser(User{Name: "testAllItemUser"})
 	var owner Owner
-	owner.UserId = user.ID
+	owner.UserID = user.ID
 	owner.Rentalable = true
 	owner.Count = 1
 	item, _ := CreateItem(Item{Name: "testAllItemItem"})
@@ -92,7 +92,7 @@ func TestGetItems(t *testing.T) {
 
 		for _, value := range items {
 			if value.Name == "testAllItemItem" {
-				assert.Equal(user.ID, value.Owners[0].UserId)
+				assert.Equal(user.ID, value.Owners[0].UserID)
 				assert.Equal(user.Name, value.Owners[0].User.Name)
 				break
 			}
@@ -106,7 +106,7 @@ func TestGetItemByID(t *testing.T) {
 	ownerUser, _ := CreateUser(User{Name: "testGetItemByIDOwner"})
 	rentalUser, _ := CreateUser(User{Name: "testGetItemByIDUser"})
 	owner := Owner{
-		UserId:     ownerUser.ID,
+		UserID:     ownerUser.ID,
 		Rentalable: true,
 		Count:      1,
 	}
@@ -117,7 +117,7 @@ func TestGetItemByID(t *testing.T) {
 		assert.NoError(err)
 		_, err = RegisterOwner(owner, item)
 		assert.NoError(err)
-		_, err = CreateLog(Log{ItemID: item.ID, OwnerId: owner.UserId, UserId: rentalUser.ID, Type: 0, Count: 1})
+		_, err = CreateLog(Log{ItemID: item.ID, OwnerID: owner.UserID, UserID: rentalUser.ID, Type: 0, Count: 1})
 		assert.NoError(err)
 
 		gotItem, err := GetItemByID(item.ID)
@@ -125,9 +125,9 @@ func TestGetItemByID(t *testing.T) {
 		assert.NoError(err)
 		assert.NotEmpty(gotItem)
 		assert.Equal(gotItem.Name, "testGetItemItem")
-		assert.Equal(gotItem.Owners[0].UserId, ownerUser.ID)
+		assert.Equal(gotItem.Owners[0].UserID, ownerUser.ID)
 		assert.Equal(gotItem.Owners[0].User.Name, ownerUser.Name)
-		assert.Equal(gotItem.Logs[0].OwnerId, ownerUser.ID)
+		assert.Equal(gotItem.Logs[0].OwnerID, ownerUser.ID)
 		assert.Equal(gotItem.Logs[0].Owner.Name, ownerUser.Name)
 		assert.Equal(gotItem.Logs[0].Count, 1)
 		assert.Equal(gotItem.Logs[0].ItemID, item.ID)
@@ -138,7 +138,7 @@ func TestGetItemByName(t *testing.T) {
 	ownerUser, _ := CreateUser(User{Name: "testGetItemByNameOwner"})
 	rentalUser, _ := CreateUser(User{Name: "testGetItemByNameUser"})
 	owner := Owner{
-		UserId:     ownerUser.ID,
+		UserID:     ownerUser.ID,
 		Rentalable: true,
 		Count:      1,
 	}
@@ -150,16 +150,16 @@ func TestGetItemByName(t *testing.T) {
 		assert.NoError(err)
 		_, err = RegisterOwner(owner, item)
 		assert.NoError(err)
-		_, err = CreateLog(Log{ItemID: item.ID, OwnerId: owner.UserId, UserId: rentalUser.ID, Type: 0, Count: 1})
+		_, err = CreateLog(Log{ItemID: item.ID, OwnerID: owner.UserID, UserID: rentalUser.ID, Type: 0, Count: 1})
 		assert.NoError(err)
 		gotItem, err := GetItemByName(item.Name)
 
 		assert.NoError(err)
 		assert.NotEmpty(gotItem)
 		assert.Equal(gotItem.Name, "testGetItemByNameItem")
-		assert.Equal(gotItem.Owners[0].UserId, ownerUser.ID)
+		assert.Equal(gotItem.Owners[0].UserID, ownerUser.ID)
 		assert.Equal(gotItem.Owners[0].User.Name, ownerUser.Name)
-		assert.Equal(gotItem.Logs[0].OwnerId, ownerUser.ID)
+		assert.Equal(gotItem.Logs[0].OwnerID, ownerUser.ID)
 		assert.Equal(gotItem.Logs[0].Owner.Name, ownerUser.Name)
 		assert.Equal(gotItem.Logs[0].Count, 1)
 		assert.Equal(gotItem.Logs[0].ItemID, item.ID)

--- a/model/logs.go
+++ b/model/logs.go
@@ -71,7 +71,7 @@ func GetLatestLog(itemID, ownerID uint) (Log, error) {
 	return log, nil
 }
 
-// GetLatestLogs 各所有者ごとの最新のログを取得する
+// GetLatestLogs 各所有者ごとの最新のログを取得する。明らかにここのクエリは冗長なのでログからLatestLogを自動生成するロジックを考えたら爆破してください(N+1のクエリが０になる)
 func GetLatestLogs(itemID uint) ([]Log, error) {
 	item := Item{}
 	item.ID = itemID

--- a/model/logs.go
+++ b/model/logs.go
@@ -51,7 +51,7 @@ func CreateLog(log Log) (Log, error) {
 	return log, nil
 }
 
-// GetLatestLog UserIdからLatestLogを取得する
+// GetLatestLog ownerIDからLatestLogを取得する
 func GetLatestLog(itemID, ownerID uint) (Log, error) {
 	item, err := GetItemByID(itemID)
 	if err != nil {
@@ -69,6 +69,20 @@ func GetLatestLog(itemID, ownerID uint) (Log, error) {
 	log := Log{}
 	db.Set("gorm:auto_preload", true).Order("created_at desc").First(&log, "item_id = ? AND owner_id = ?", itemID, ownerID)
 	return log, nil
+}
+
+func GetLatestLogs(itemID uint) ([]Log, error) {
+	item, err := GetItemByID(itemID)
+	if err != nil {
+		return []Log{}, err
+	}
+	logs := []Log{}
+	log := Log{}
+	for i, owner := range item.Owners {
+		db.Set("gorm:auto_preload", true).Order("created_at desc").First(&log, "item_id = ? AND owner_id = ?", itemID, owner.ID)
+		logs[i] = log
+	}
+	return logs, nil
 }
 
 // GetLogsByItemID itemIDからLogsを取得する

--- a/model/logs.go
+++ b/model/logs.go
@@ -11,9 +11,9 @@ import (
 type Log struct {
 	gorm.Model
 	ItemID  uint      `gorm:"type:int;not null" json:"item_id"`
-	UserId  uint      `gorm:"type:int;not null" json:"user_id"`
+	UserID  uint      `gorm:"type:int;not null" json:"user_id"`
 	User    User      `json:"user"`
-	OwnerId uint      `gorm:"type:int;not null" json:"owner_id"`
+	OwnerID uint      `gorm:"type:int;not null" json:"owner_id"`
 	Owner   User      `json:"owner"`
 	Type    int       `gorm:"type:int;not null" json:"type"`
 	Purpose string    `json:"purpose"`
@@ -43,7 +43,7 @@ func CreateLog(log Log) (Log, error) {
 	if err != nil {
 		return Log{}, errors.New("Itemが存在しません")
 	}
-	_, err = GetUserByID(int(log.OwnerId))
+	_, err = GetUserByID(int(log.OwnerID))
 	if err != nil {
 		return Log{}, errors.New("Ownerが存在しません")
 	}
@@ -59,7 +59,7 @@ func GetLatestLog(itemID, ownerID uint) (Log, error) {
 	}
 	exist := false
 	for _, owner := range item.Owners {
-		if owner.UserId == ownerID {
+		if owner.UserID == ownerID {
 			exist = true
 		}
 	}
@@ -83,7 +83,7 @@ func GetLatestLogs(itemID uint) ([]Log, error) {
 	log := Log{}
 	log.ItemID = itemID
 	for _, owner := range item.Owners {
-		log.OwnerId = owner.ID
+		log.OwnerID = owner.ID
 		db.Set("gorm:auto_preload", true).Order("created_at desc").First(&log)
 		if log.ID == 0 {
 			continue

--- a/model/logs_test.go
+++ b/model/logs_test.go
@@ -21,7 +21,7 @@ func TestCreateLog(t *testing.T) {
 		assert.Error(err)
 		assert.Empty(log)
 
-		log, err = CreateLog(Log{ItemID: 66, OwnerID: 66})
+		log, err = CreateLog(Log{ItemID: 66, OwnerId: 66})
 		assert.Error(err)
 		assert.Empty(log)
 	})
@@ -32,71 +32,83 @@ func TestCreateLog(t *testing.T) {
 		owner, _ := GetUserByName("traP")
 		item, _ := CreateItem(Item{Name: "testItemForCreateLog"})
 
-		log, err := CreateLog(Log{ItemID: item.ID, OwnerID: owner.ID, Type: 0})
+		log, err := CreateLog(Log{ItemID: item.ID, OwnerId: owner.ID, Type: 0})
 		assert.NoError(err)
 		assert.NotEmpty(log)
-		assert.Equal(owner.ID, log.OwnerID)
+		assert.Equal(owner.ID, log.OwnerId)
 		assert.Equal(item.ID, log.ItemID)
 	})
 }
 
 func TestGetLogsByItemID(t *testing.T) {
-	t.Parallel()
 
 	t.Run("success", func(t *testing.T) {
 		assert := assert.New(t)
 
-		owner, _ := GetUserByName("traP")
-		item, _ := CreateItem(Item{Name: "testItemForGetLogsByItemID"})
-		_, err := RegisterOwner(Owner{OwnerID: owner.ID, Rentalable: true, Count: 1}, item)
+		user, err := CreateUser(User{Name: "testGetLogsByItemIDUser"})
 		assert.NoError(err)
-
-		log, err := CreateLog(Log{ItemID: item.ID, OwnerID: owner.ID, UserID: owner.ID, Type: 0, Count: 0})
+		owner, err := CreateUser(User{Name: "testGetLogsByItemIDOwner"})
+		assert.NoError(err)
+		item, err := CreateItem(Item{Name: "testItemForGetLogsByItemID"})
+		assert.NoError(err)
+		_, err = RegisterOwner(Owner{UserId: owner.ID, Rentalable: true, Count: 1}, item)
+		assert.NoError(err)
+		log, err := CreateLog(Log{ItemID: item.ID, OwnerId: owner.ID, UserId: user.ID, Type: 0, Count: 0})
 		assert.NoError(err)
 		logs, err := GetLogsByItemID(item.ID)
+
 		assert.NoError(err)
 		assert.NotEmpty(logs)
 		assert.Equal(logs[0].ItemID, log.ItemID)
-		assert.Equal(logs[0].OwnerID, log.OwnerID)
+		assert.Equal(logs[0].OwnerId, log.OwnerId)
+		assert.Equal(logs[0].Owner.Name, owner.Name)
+		assert.Equal(logs[0].User.Name, user.Name)
 	})
 }
 
 // 今は時間がなくていい感じにテストをかけていませんが未来誰かがテストを書いてくれる日を願って確率でうまくいくテストを残しておきます。テストを書いたらこのコメントは消してください　	ryoha
-// func TestGetLatestLog(t *testing.T) {
-// 	t.Parallel()
+func TestGetLatestLog(t *testing.T) {
 
-// 	item, _ := CreateItem(Item{Name: "testGetLatestLogItem"})
-// 	itemID := item.ID
+	item, _ := CreateItem(Item{Name: "testGetLatestLogItem"})
+	itemID := item.ID
+	user, _ := CreateUser(User{Name: "testGetUserLatestLogUser"})
+	ownerUser, _ := GetUserByName("traP")
+	owner := Owner{
+		UserId:     ownerUser.ID,
+		Rentalable: true,
+		Count:      1,
+	}
+	_, _ = RegisterOwner(owner, item)
+	_, _ = CreateLog(Log{ItemID: itemID, UserId: user.ID, OwnerId: ownerUser.ID, Type: 0, Count: 1})
 
-// 	user, _ := GetUserByName("traP")
-// 	owner := Owner{
-// 		OwnerID:    user.ID,
-// 		Rentalable: true,
-// 		Count:      1,
-// 	}
-// 	_, _ = RegisterOwner(owner, item)
-// 	_, _ = CreateLog(Log{ItemID: itemID, OwnerID: user.ID, Type: 0, Count: 1})
+	t.Run("failures", func(t *testing.T) {
+		assert := assert.New(t)
 
-// 	t.Run("failures", func(t *testing.T) {
-// 		assert := assert.New(t)
+		_, err := RegisterOwner(owner, item)
+		assert.NoError(err)
+		_, err = CreateLog(Log{ItemID: itemID, UserId: user.ID, OwnerId: ownerUser.ID, Type: 0, Count: 1})
+		assert.NoError(err)
 
-// 		log, err := GetLatestLog(66, 66)
-// 		assert.Error(err)
-// 		assert.Empty(log)
+		log, err := GetLatestLog(66, 66)
+		assert.Error(err)
+		assert.Empty(log)
 
-// 		log, err = GetLatestLog(itemID, 66)
-// 		assert.Error(err)
-// 		assert.Empty(log)
-// 	})
+		log, err = GetLatestLog(itemID, 66)
+		assert.Error(err)
+		assert.Empty(log)
+	})
 
-// 	t.Run("success", func(t *testing.T) {
-// 		assert := assert.New(t)
+	t.Run("success", func(t *testing.T) {
+		assert := assert.New(t)
 
-// 		log, err := GetLatestLog(itemID, user.ID)
-// 		assert.NoError(err)
-// 		assert.NotEmpty(log)
-// 		assert.Equal(user.ID, log.OwnerID)
-// 		assert.Equal(itemID, log.ItemID)
-// 		assert.Equal(0, log.Type)
-// 	})
-// }
+		log, err := GetLatestLog(itemID, ownerUser.ID)
+		assert.NoError(err)
+		assert.NotEmpty(log)
+		t.Log(log)
+		assert.Equal(ownerUser.ID, log.OwnerId)
+		assert.Equal(ownerUser.Name, log.Owner.Name)
+		assert.Equal(user.Name, log.User.Name)
+		assert.Equal(itemID, log.ItemID)
+		assert.Equal(0, log.Type)
+	})
+}

--- a/model/logs_test.go
+++ b/model/logs_test.go
@@ -65,58 +65,17 @@ func TestGetLogsByItemID(t *testing.T) {
 	})
 }
 
-// 今は時間がなくていい感じにテストをかけていませんが未来誰かがテストを書いてくれる日を願って確率でうまくいくテストを残しておきます。テストを書いたらこのコメントは消してください　	ryoha
-func TestGetLatestLog(t *testing.T) {
-	item, _ := CreateItem(Item{Name: "testGetLatestLogItem"})
-	itemID := item.ID
-	user, _ := CreateUser(User{Name: "testGetUserLatestLogUser"})
-	ownerUser, _ := GetUserByName("traP")
-	owner := Owner{
-		UserId:     ownerUser.ID,
-		Rentalable: true,
-		Count:      1,
-	}
-	_, _ = RegisterOwner(owner, item)
-	_, _ = CreateLog(Log{ItemID: itemID, UserId: user.ID, OwnerId: ownerUser.ID, Type: 0, Count: 1})
-
-	t.Run("failures", func(t *testing.T) {
-		assert := assert.New(t)
-
-		_, err := RegisterOwner(owner, item)
-		assert.NoError(err)
-		_, err = CreateLog(Log{ItemID: itemID, UserId: user.ID, OwnerId: ownerUser.ID, Type: 0, Count: 1})
-		assert.NoError(err)
-
-		log, err := GetLatestLog(66, 66)
-		assert.Error(err)
-		assert.Empty(log)
-
-		log, err = GetLatestLog(itemID, 66)
-		assert.Error(err)
-		assert.Empty(log)
-	})
-
-	t.Run("success", func(t *testing.T) {
-		assert := assert.New(t)
-
-		log, err := GetLatestLog(itemID, ownerUser.ID)
-		assert.NoError(err)
-		assert.NotEmpty(log)
-		t.Log(log)
-		assert.Equal(ownerUser.ID, log.OwnerId)
-		assert.Equal(ownerUser.Name, log.Owner.Name)
-		assert.Equal(user.Name, log.User.Name)
-		assert.Equal(itemID, log.ItemID)
-		assert.Equal(0, log.Type)
-	})
-}
-
 func TestGetLatestLogs(t *testing.T) {
-	item, _ := CreateItem(Item{Name: "testGetLatestLogItem"})
+	assert := assert.New(t)
+	item, err := CreateItem(Item{Name: "testGetLatestLogItem"})
+	assert.NoError(err)
 	itemID := item.ID
-	user1, _ := CreateUser(User{Name: "testGetUserLatestLogUser"})
-	user2, _ := CreateUser(User{Name: "testGetUserLatestLogUser"})
-	ownerUser1, _ := GetUserByName("traP")
+	user1, err := CreateUser(User{Name: "testGetUserLatestLogUser1"})
+	assert.NoError(err)
+	user2, err := CreateUser(User{Name: "testGetUserLatestLogUser2"})
+	assert.NoError(err)
+	ownerUser1, err := GetUserByName("traP")
+	assert.NoError(err)
 	owner1 := Owner{
 		UserId:     ownerUser1.ID,
 		Rentalable: true,
@@ -129,9 +88,17 @@ func TestGetLatestLogs(t *testing.T) {
 		Count:      1,
 	}
 
-	t.Run("success", func(t *testing.T) {
-		assert := assert.New(t)
+	t.Run("failures", func(t *testing.T) {
+		log, err := GetLatestLog(66, 66)
+		assert.Error(err)
+		assert.Empty(log)
 
+		log, err = GetLatestLog(itemID, 66)
+		assert.Error(err)
+		assert.Empty(log)
+	})
+
+	t.Run("success", func(t *testing.T) {
 		_, err := RegisterOwner(owner1, item)
 		assert.NoError(err)
 		_, err = RegisterOwner(owner2, item)

--- a/model/logs_test.go
+++ b/model/logs_test.go
@@ -21,7 +21,7 @@ func TestCreateLog(t *testing.T) {
 		assert.Error(err)
 		assert.Empty(log)
 
-		log, err = CreateLog(Log{ItemID: 66, OwnerId: 66})
+		log, err = CreateLog(Log{ItemID: 66, OwnerID: 66})
 		assert.Error(err)
 		assert.Empty(log)
 	})
@@ -32,10 +32,10 @@ func TestCreateLog(t *testing.T) {
 		owner, _ := GetUserByName("traP")
 		item, _ := CreateItem(Item{Name: "testItemForCreateLog"})
 
-		log, err := CreateLog(Log{ItemID: item.ID, OwnerId: owner.ID, Type: 0})
+		log, err := CreateLog(Log{ItemID: item.ID, OwnerID: owner.ID, Type: 0})
 		assert.NoError(err)
 		assert.NotEmpty(log)
-		assert.Equal(owner.ID, log.OwnerId)
+		assert.Equal(owner.ID, log.OwnerID)
 		assert.Equal(item.ID, log.ItemID)
 	})
 }
@@ -50,16 +50,16 @@ func TestGetLogsByItemID(t *testing.T) {
 		assert.NoError(err)
 		item, err := CreateItem(Item{Name: "testItemForGetLogsByItemID"})
 		assert.NoError(err)
-		_, err = RegisterOwner(Owner{UserId: owner.ID, Rentalable: true, Count: 1}, item)
+		_, err = RegisterOwner(Owner{UserID: owner.ID, Rentalable: true, Count: 1}, item)
 		assert.NoError(err)
-		log, err := CreateLog(Log{ItemID: item.ID, OwnerId: owner.ID, UserId: user.ID, Type: 0, Count: 0})
+		log, err := CreateLog(Log{ItemID: item.ID, OwnerID: owner.ID, UserID: user.ID, Type: 0, Count: 0})
 		assert.NoError(err)
 		logs, err := GetLogsByItemID(item.ID)
 
 		assert.NoError(err)
 		assert.NotEmpty(logs)
 		assert.Equal(logs[0].ItemID, log.ItemID)
-		assert.Equal(logs[0].OwnerId, log.OwnerId)
+		assert.Equal(logs[0].OwnerID, log.OwnerID)
 		assert.Equal(logs[0].Owner.Name, owner.Name)
 		assert.Equal(logs[0].User.Name, user.Name)
 	})
@@ -77,13 +77,13 @@ func TestGetLatestLogs(t *testing.T) {
 	ownerUser1, err := GetUserByName("traP")
 	assert.NoError(err)
 	owner1 := Owner{
-		UserId:     ownerUser1.ID,
+		UserID:     ownerUser1.ID,
 		Rentalable: true,
 		Count:      1,
 	}
 	ownerUser2, _ := GetUserByName("sienka")
 	owner2 := Owner{
-		UserId:     ownerUser2.ID,
+		UserID:     ownerUser2.ID,
 		Rentalable: true,
 		Count:      1,
 	}
@@ -103,28 +103,28 @@ func TestGetLatestLogs(t *testing.T) {
 		assert.NoError(err)
 		_, err = RegisterOwner(owner2, item)
 		assert.NoError(err)
-		_, err = CreateLog(Log{ItemID: itemID, UserId: user1.ID, OwnerId: ownerUser1.ID, Type: 0, Count: 0})
+		_, err = CreateLog(Log{ItemID: itemID, UserID: user1.ID, OwnerID: ownerUser1.ID, Type: 0, Count: 0})
 		assert.NoError(err)
-		_, err = CreateLog(Log{ItemID: itemID, UserId: user2.ID, OwnerId: ownerUser1.ID, Type: 0, Count: 1})
+		_, err = CreateLog(Log{ItemID: itemID, UserID: user2.ID, OwnerID: ownerUser1.ID, Type: 0, Count: 1})
 		assert.NoError(err)
-		_, err = CreateLog(Log{ItemID: itemID, UserId: user2.ID, OwnerId: ownerUser2.ID, Type: 0, Count: 0})
+		_, err = CreateLog(Log{ItemID: itemID, UserID: user2.ID, OwnerID: ownerUser2.ID, Type: 0, Count: 0})
 		assert.NoError(err)
-		_, err = CreateLog(Log{ItemID: itemID, UserId: user1.ID, OwnerId: ownerUser2.ID, Type: 0, Count: 1})
+		_, err = CreateLog(Log{ItemID: itemID, UserID: user1.ID, OwnerID: ownerUser2.ID, Type: 0, Count: 1})
 		assert.NoError(err)
 
 		logs, err := GetLatestLogs(itemID)
 		assert.NoError(err)
 		assert.NotEmpty(logs)
 		for _, log := range logs {
-			if log.OwnerId == ownerUser1.ID {
+			if log.OwnerID == ownerUser1.ID {
 				assert.Equal(ownerUser1.Name, log.Owner.Name)
-				assert.Equal(user2.ID, log.UserId)
+				assert.Equal(user2.ID, log.UserID)
 				assert.Equal(user2.Name, log.User.Name)
 				assert.Equal(1, log.Count)
 			}
-			if log.OwnerId == ownerUser2.ID {
+			if log.OwnerID == ownerUser2.ID {
 				assert.Equal(ownerUser2.Name, log.Owner.Name)
-				assert.Equal(user1.ID, log.UserId)
+				assert.Equal(user1.ID, log.UserID)
 				assert.Equal(user1.Name, log.User.Name)
 				assert.Equal(1, log.Count)
 			}

--- a/model/logs_test.go
+++ b/model/logs_test.go
@@ -41,7 +41,6 @@ func TestCreateLog(t *testing.T) {
 }
 
 func TestGetLogsByItemID(t *testing.T) {
-
 	t.Run("success", func(t *testing.T) {
 		assert := assert.New(t)
 
@@ -68,7 +67,6 @@ func TestGetLogsByItemID(t *testing.T) {
 
 // 今は時間がなくていい感じにテストをかけていませんが未来誰かがテストを書いてくれる日を願って確率でうまくいくテストを残しておきます。テストを書いたらこのコメントは消してください　	ryoha
 func TestGetLatestLog(t *testing.T) {
-
 	item, _ := CreateItem(Item{Name: "testGetLatestLogItem"})
 	itemID := item.ID
 	user, _ := CreateUser(User{Name: "testGetUserLatestLogUser"})

--- a/router/items.go
+++ b/router/items.go
@@ -88,7 +88,7 @@ func PostOwners(c echo.Context) error {
 		return c.NoContent(http.StatusForbidden)
 	}
 	owner := model.Owner{
-		UserId:     user.ID,
+		UserID:     user.ID,
 		Rentalable: body.Rentalable,
 		Count:      body.Count,
 	}

--- a/router/items.go
+++ b/router/items.go
@@ -88,7 +88,7 @@ func PostOwners(c echo.Context) error {
 		return c.NoContent(http.StatusForbidden)
 	}
 	owner := model.Owner{
-		OwnerID:    user.ID,
+		UserId:     user.ID,
 		Rentalable: body.Rentalable,
 		Count:      body.Count,
 	}

--- a/router/items_test.go
+++ b/router/items_test.go
@@ -141,7 +141,7 @@ func TestPostOwners(t *testing.T) {
 		_ = json.NewDecoder(rec.Body).Decode(&item)
 
 		assert.Equal(testBodyTrap.Name, item.Name)
-		assert.Equal(trap.ID, item.Owners[0].UserId)
+		assert.Equal(trap.ID, item.Owners[0].UserID)
 	})
 
 	t.Run("not admin user", func(t *testing.T) {
@@ -196,6 +196,6 @@ func TestPostOwners(t *testing.T) {
 		_ = json.NewDecoder(rec.Body).Decode(&item)
 
 		assert.Equal(testBodyKojin.Name, item.Name)
-		assert.Equal(testUser.ID, item.Owners[0].UserId)
+		assert.Equal(testUser.ID, item.Owners[0].UserID)
 	})
 }

--- a/router/items_test.go
+++ b/router/items_test.go
@@ -141,7 +141,7 @@ func TestPostOwners(t *testing.T) {
 		_ = json.NewDecoder(rec.Body).Decode(&item)
 
 		assert.Equal(testBodyTrap.Name, item.Name)
-		assert.Equal(trap.ID, item.Owners[0].OwnerID)
+		assert.Equal(trap.ID, item.Owners[0].UserId)
 	})
 
 	t.Run("not admin user", func(t *testing.T) {
@@ -196,6 +196,6 @@ func TestPostOwners(t *testing.T) {
 		_ = json.NewDecoder(rec.Body).Decode(&item)
 
 		assert.Equal(testBodyKojin.Name, item.Name)
-		assert.Equal(testUser.ID, item.Owners[0].OwnerID)
+		assert.Equal(testUser.ID, item.Owners[0].UserId)
 	})
 }

--- a/router/logs.go
+++ b/router/logs.go
@@ -28,7 +28,7 @@ func PostLogs(c echo.Context) error {
 	item, _ := model.GetItemByID(itemID)
 	var itemCount int
 	for _, owner := range item.Owners {
-		if owner.UserId == body.OwnerID {
+		if owner.UserID == body.OwnerID {
 			if !owner.Rentalable {
 				return c.NoContent(http.StatusForbidden)
 			}
@@ -42,8 +42,8 @@ func PostLogs(c echo.Context) error {
 	}
 	log := model.Log{
 		ItemID:  itemID,
-		UserId:  user.ID,
-		OwnerId: body.OwnerID,
+		UserID:  user.ID,
+		OwnerID: body.OwnerID,
 		Type:    body.Type,
 		Purpose: body.Purpose,
 		DueDate: body.DueDate,

--- a/router/logs.go
+++ b/router/logs.go
@@ -28,7 +28,7 @@ func PostLogs(c echo.Context) error {
 	item, _ := model.GetItemByID(itemID)
 	var itemCount int
 	for _, owner := range item.Owners {
-		if owner.OwnerID == body.OwnerID {
+		if owner.UserId == body.OwnerID {
 			if !owner.Rentalable {
 				return c.NoContent(http.StatusForbidden)
 			}
@@ -42,8 +42,8 @@ func PostLogs(c echo.Context) error {
 	}
 	log := model.Log{
 		ItemID:  itemID,
-		UserID:  user.ID,
-		OwnerID: body.OwnerID,
+		UserId:  user.ID,
+		OwnerId: body.OwnerID,
 		Type:    body.Type,
 		Purpose: body.Purpose,
 		DueDate: body.DueDate,


### PR DESCRIPTION
これからクエリ書く人は`.Set("gorm:auto_preload", true)`をつけてWhere句を使わなかったら大体何とかなります