### PR TITLE
traP所有のもの(type:0)は一般ユーザーが持てないように

### DIFF
--- a/router/items.go
+++ b/router/items.go
@@ -127,6 +127,9 @@ func PostOwners(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, err)
 	}
+	if body.UserID > 2 && item.Type > 0 {
+		return c.NoContent(http.StatusForbidden)
+	}
 	if item.Type == 1 {
 		user, _ = model.GetUserByName("traP")
 	}


### PR DESCRIPTION
本については次回集会で
clientは触ってないのでボタンとかが出ますがエラーが返ってくる(はず)です
Close #186 