### PR TITLE
開発環境はAPIを認証なしに叩けるようにした

### DIFF
--- a/client/src/components/core/SideBar.vue
+++ b/client/src/components/core/SideBar.vue
@@ -91,6 +91,12 @@
           バグ報告・フィードバックは<a href="https://q.trap.jp/channels/team/SysAd/booq/feedback">#team/SysAd/booq/feedback</a>までお願いします。<br>
           GitHubリポジトリ: <a href="https://github.com/traPtitech/booQ">traPtitech/booQ</a><br>
         </v-card-text>
+        <v-btn
+          v-if="version === 'dev'"
+          @click="$store.commit('toggleLoginDialog')"
+        >
+          traQ login
+        </v-btn>
       </v-card>
     </v-dialog>
   </v-navigation-drawer>

--- a/main.go
+++ b/main.go
@@ -42,7 +42,18 @@ func main() {
 	}))
 
 	// Routing
-	router.SetupRouting(e, &router.TraqClient{})
+	if os.Getenv("BOOQ_ENV") == "development" {
+		mockClient := &router.MockTraqClient{
+			MockGetUsersMe: func(c echo.Context) (echo.Context, error) {
+				user, _ := model.GetUserByName("sienka")
+				c.Set("user", user)
+				return c, nil
+			},
+		}
+		router.SetupRouting(e, mockClient)
+	} else {
+		router.SetupRouting(e, &router.TraqClient{})
+	}
 
 	// Start server
 	e.Logger.Fatal(e.Start(":3001"))


### PR DESCRIPTION
Close #108 

開発環境はアクセスユーザーを`sienka`に偽装することで認証過程を回避するようにしました。
これによって開発環境はブラウザからのAPIアクセスが可能になりました。

この影響でクライアント側のtraQとやりとりする部分(アイコンの画像読み込みとtraQへの投稿)が自動的にできなくなりましたが、開発環境だけ画像のように明示的にtraQと接続するボタンを設置することで今まで通りtraQともやりとりできるようにしました
![image](https://user-images.githubusercontent.com/24384201/67120580-8aa00c80-f224-11e9-9f3d-3289ca31a25d.png)
