### PR TITLE
開発用Dockerfile修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,13 @@ RUN apk add --update --no-cache git && \
   apk --update add tzdata && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   apk del tzdata && \
-  rm -rf /var/cache/apk/* && \
-  wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+  rm -rf /var/cache/apk/*
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
   tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
   rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 WORKDIR /go/src/github.com/traPtitech/booQ
+RUN go get github.com/pilu/fresh
 COPY ./go.* ./
-RUN go mod download && \
-  go get github.com/pilu/fresh && \
-  go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.27.0
-
+RUN go mod download
 COPY . .


### PR DESCRIPTION
主な変更点は
- git,tzdataのインストールとdockerizeのインストールの分離
- freshのインストールを`go mod download`と分離して、`./go.*`の変更にかかわらずキャッシュが効くようにした
- 使っていないっぽい`golangci-lint`をインストールの対象から除外

`golangci-lint`に関しては、もし使っているようなら`curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0`で入れるように変更します。
Close #371 