### PR TITLE
service/booQへのbooQ botのコメントの投稿時、ユーザー名を表示するようにする。

### DIFF
--- a/router/comments.go
+++ b/router/comments.go
@@ -43,7 +43,7 @@ func PostComments(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, err)
 	}
 	itemInfo := fmt.Sprintf("[%v](https://%v/items/%v)", item.Name, os.Getenv("HOST"), item.ID)
-	message := fmt.Sprintf("### コメントを投稿しました\n%v\n%v", itemInfo, comment.Text)
+	message := fmt.Sprintf("### @%s がコメントを投稿しました\n%s\n%s", comment.User.DisplayName, itemInfo, comment.Text)
 	_ = PostMessage(c, message, false)
 	return c.JSON(http.StatusCreated, res)
 }

--- a/router/comments.go
+++ b/router/comments.go
@@ -43,7 +43,7 @@ func PostComments(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, err)
 	}
 	itemInfo := fmt.Sprintf("[%v](https://%v/items/%v)", item.Name, os.Getenv("HOST"), item.ID)
-	message := fmt.Sprintf("### @%s がコメントを投稿しました\n%s\n%s", comment.User.DisplayName, itemInfo, comment.Text)
+	message := fmt.Sprintf("### @%s がコメントを投稿しました\n%s\n%s", comment.User.Name, itemInfo, comment.Text)
 	_ = PostMessage(c, message, false)
 	return c.JSON(http.StatusCreated, res)
 }


### PR DESCRIPTION
service/booQへのbooQ botのコメントの投稿時、ユーザー名を表示するようにする。
実装方法：
router/comments.goのPostComments関数の中のmessageの定義にUserIDを追加する。
46行目
```
message := fmt.Sprintf("### コメントを投稿しました\n%v\n%v", itemInfo, comment.Text, comment.UserID)
```
Close #389