### PR TITLE
透明な画像を上げると背景が黒くなる問題の修正

### DIFF
--- a/router/files.go
+++ b/router/files.go
@@ -4,12 +4,16 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"net/http"
+	"strconv"
+
 	"github.com/disintegration/imaging"
 	"github.com/labstack/echo"
 	"github.com/traPtitech/booQ/model"
 	"github.com/traPtitech/booQ/storage"
-	"net/http"
-	"strconv"
 )
 
 // アップロードを許可するMIMEタイプ
@@ -46,8 +50,12 @@ func PostFile(c echo.Context) error {
 		// 不正な画像
 		return c.JSON(http.StatusBadRequest, errors.New("不正なファイルです"))
 	}
+	// 背景を透明にする
+	newImg := image.NewRGBA(orig.Bounds())
+	draw.Draw(newImg, newImg.Bounds(), &image.Uniform{color.White}, image.Point{}, draw.Src)
+	draw.Draw(newImg, newImg.Bounds(), orig, orig.Bounds().Min, draw.Over)
 	b := &bytes.Buffer{}
-	_ = imaging.Encode(b, imaging.Fit(orig, 360, 480, imaging.Linear), imaging.JPEG, imaging.JPEGQuality(85))
+	_ = imaging.Encode(b, imaging.Fit(newImg, 360, 480, imaging.Linear), imaging.JPEG, imaging.JPEGQuality(85))
 
 	// 保存
 	f, err := model.CreateFile(user.ID, b, "jpg")

--- a/router/files.go
+++ b/router/files.go
@@ -55,8 +55,11 @@ func PostFile(c echo.Context) error {
 	draw.Draw(newImg, newImg.Bounds(), &image.Uniform{color.White}, image.Point{}, draw.Src)
 	draw.Draw(newImg, newImg.Bounds(), orig, orig.Bounds().Min, draw.Over)
 	b := &bytes.Buffer{}
-	_ = imaging.Encode(b, imaging.Fit(newImg, 360, 480, imaging.Linear), imaging.JPEG, imaging.JPEGQuality(85))
-
+	err = imaging.Encode(b, imaging.Fit(newImg, 360, 480, imaging.Linear), imaging.JPEG, imaging.JPEGQuality(85))
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+	
 	// 保存
 	f, err := model.CreateFile(user.ID, b, "jpg")
 	if err != nil {


### PR DESCRIPTION
背景を白色にするようにしました。
`&image.Uniform{color.Transparent}`で背景を透明にできるようにしようとしたのですが、うまくいかず背景が真っ黒になってしまったため、`&image.Uniform{color.White}`を使いました。
背景が透明なPNGを手元でアップロードしたら、背景が白くなることが確認できました。