### PR TITLE
/items/:id/logs でpurposeフィールドを省略できるように

### DIFF
--- a/model/logs.go
+++ b/model/logs.go
@@ -36,7 +36,7 @@ const (
 type RequestPostLogsBody struct {
 	OwnerID uint   `json:"ownerId"`
 	Type    int    `json:"type"`
-	Purpose string `json:"purpose"`
+	Purpose string `json:"purpose,omitempty"`
 	DueDate string `json:"dueDate"`
 	Count   int    `json:"count"`
 }
@@ -58,7 +58,6 @@ func (body RequestPostLogsBody) Validate() error {
 	return validation.ValidateStruct(&body,
 		validation.Field(&body.OwnerID, validation.Required),
 		validation.Field(&body.Type, validation.By(checkLogsType)),
-		validation.Field(&body.Purpose, validation.Required),
 		validation.Field(&body.DueDate, validation.Date("2006-01-02")),
 		validation.Field(&body.Count, validation.Required),
 	)

--- a/router/logs_test.go
+++ b/router/logs_test.go
@@ -81,13 +81,6 @@ func TestPostLogs(t *testing.T) {
 		{
 			OwnerID: trap.ID,
 			Type:    0,
-			Purpose: "",
-			DueDate: "2000-02-16",
-			Count:   1,
-		},
-		{
-			OwnerID: trap.ID,
-			Type:    0,
 			Purpose: "ログのポストのテストのPurposeですvalidation error4",
 			DueDate: "2000/02/16",
 			Count:   1,


### PR DESCRIPTION
fix #543